### PR TITLE
fix: update location preferences before navigating from search screen…

### DIFF
--- a/app/src/main/java/com/example/weatherjourney/features/weather/presentation/search/WeatherSearchScreen.kt
+++ b/app/src/main/java/com/example/weatherjourney/features/weather/presentation/search/WeatherSearchScreen.kt
@@ -100,10 +100,7 @@ fun WeatherSearchScreen(
         WeatherSearchScreenContent(
             uiState = uiState,
             onRefresh = viewModel::onRefresh,
-            onCityClick = {
-                viewModel.onItemClick(it)
-                onItemClick(it)
-            },
+            onCityClick = { viewModel.onItemClick(it, onItemClick) },
             onCityLongClick = viewModel::onSavedCityLongClick,
             onCurrentLocationFieldClick = viewModel::onLocationFieldClick,
             modifier = Modifier.padding(paddingValues),

--- a/app/src/main/java/com/example/weatherjourney/features/weather/presentation/search/WeatherSearchViewModel.kt
+++ b/app/src/main/java/com/example/weatherjourney/features/weather/presentation/search/WeatherSearchViewModel.kt
@@ -201,7 +201,7 @@ class WeatherSearchViewModel @Inject constructor(
         }
     }
 
-    fun onItemClick(city: CityUiModel) = viewModelScope.launch {
+    fun onItemClick(city: CityUiModel, onItemClick: (CityUiModel) -> Unit) = viewModelScope.launch {
         when (city) {
             is SavedCity -> {
                 appPreferences.updateLocation(
@@ -221,6 +221,8 @@ class WeatherSearchViewModel @Inject constructor(
                 )
             }
         }
+
+        onItemClick(city)
     }
 
     private fun handleLocations(channel: Channel<SavedCity?>, locations: List<LocationEntity>) {


### PR DESCRIPTION
… to info screen

Previously, the location preferences were updated after navigating from the search screen to the info screen. This resulted in outdated location and weather data being displayed on the info screen.